### PR TITLE
Fix radio and checkbox first selection bug.

### DIFF
--- a/src/dominar.js
+++ b/src/dominar.js
@@ -408,13 +408,22 @@
 		 * @return {mixed}
 		 */
 		getValue: function() {
-			var $field = this.$field;
+			return this.getField().val();
+		},
+
+		/**
+		 * Get field
+		 *
+		 * @return {jQuery}
+		 */
+		getField: function() {
+			var $field = this.$container.find('[name="' + this.name + '"]');
 			var type = $field[0].type;
 			if (type == 'radio' || type == 'checkbox')
 			{
-				$field = $field.filter(':checked');
+				return $field.filter(':checked');
 			}
-			return $field.val();
+			return $field;
 		},
 
 		/**


### PR DESCRIPTION
The first checkbox or radio button selected determined whether the
group was valid. Now any checkbox/radio button can be selected in order.
